### PR TITLE
Update docker PHP to 7.2.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: php
 
 php:
-  - 7.1
+  - 7.2.9
 
 services:
   - postgresql

--- a/app.dockerfile
+++ b/app.dockerfile
@@ -12,7 +12,9 @@ RUN apt-get update && apt-get install -y libmcrypt-dev \
 
 RUN apt-get update \
     && apt-get install -y git unzip \
+    && apt-get install -y zlib1g-dev \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && apt-get -y autoremove \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && docker-php-ext-install zip 

--- a/app.dockerfile
+++ b/app.dockerfile
@@ -1,18 +1,17 @@
-FROM php:7.1.7-fpm
+FROM php:7.2.9-fpm
 
 # Runtime
 
 RUN apt-get update && apt-get install -y libmcrypt-dev \
     libpq-dev --no-install-recommends \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install mcrypt pdo_pgsql pgsql 
+    && docker-php-ext-install pdo_pgsql pgsql 
 
 # Tools
 # Git, Zip, Composer
 
-RUN docker-php-ext-install zip \ 
-    && apt-get update \
-    && apt-get install -y git zip unzip \
+RUN apt-get update \
+    && apt-get install -y git unzip \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && apt-get -y autoremove \
     && apt-get clean \


### PR DESCRIPTION
Propongo actualizar el ambiente de Docker a la version de PHP que maneja Heroku (7.2.9 actualmente).
Surgió a partir de un error #247 no reproducible en el ambiente de desarrollo. Seguramente lleve a otros conflictos similares.

En la actualización dejan de soportar count(NULL) y sizeof(NULL) por lo que habría que agregar verificaciones antes de usarlos.